### PR TITLE
feat: Initializes speed estimation as a separate add on

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Speed Estimation
 
-This add-on calculates the direction of movement of trackable objects based on their past and present coordinates in the frame. We implement the speed estimation algorithm proposed on the following paper:
+This add-on calculates the speed of trackable objects based on their past and present coordinates in the frame. We implement the speed estimation algorithm proposed on the following paper:
 
 <https://ieeexplore.ieee.org/document/6614066>
 

--- a/README.md
+++ b/README.md
@@ -56,5 +56,5 @@ When the flag `person_action`, we perform an additional processing step, where w
 The add-on's output is shared on the `AddonObject.inference.extra` for each object that was actively tracked by the `tracking` add-on on the current frame:
 
 - `AddonObject.inference.extra['current_speed']` - (format: `dict` where `{'obj_id': speed}`)
-- `AddonObject.inference.extra['current_action']` - (format: `dict` where `{'obj_id': speed}`)
+- `AddonObject.inference.extra['current_action']` - (format: `dict` where `{'obj_id': action}`)
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,60 @@
-# vsdkx-addon-speed-estimation
+# Speed Estimation
+
+This add-on calculates the direction of movement of trackable objects based on their past and present coordinates in the frame. We implement the speed estimation algorithm proposed on the following paper:
+
+<https://ieeexplore.ieee.org/document/6614066>
+
+
+### Config
+
+The class `SpeedEstimationProcessor` is initialized with the following config parameters. The majority of the below parameters rely on the tech specifications of the input camera,
+
+```python
+DEFAULT = {
+    "person_action": True,
+    "camera_length": 4.5,
+    "fps": 30,
+    "lens_dimension": 0,
+    "focal_length": 0,
+    "camera_horizontal_degrees": 80,
+    "camera_vertical_degrees": 53
+}
+```
+
+where:
+- `person_aciton` (bool): Calculates the following actions for person detections - `walking | running | standing`
+- `camera_length` (float | int): The maximum distance of the camera to the scene
+- `fps` (int): Frames per second
+- `lens_dimension` (int): The camera's lens dimension in millimeters. This value is optional if the `camera_horizontal_degrees` and `camera_vertical_degrees` are specified instead.
+- `focal_length` (int): The camera's focal length in millimeters. The value is optional if the `camera_horizontal_degrees` and `camera_vertical_degrees` are specified instead. 
+- `camera_horizontal_degrees` (int): The camera's horizontal view in degrees. The value is optional if the `lens_dimension` and `focal_length` are specified instead. 
+- `camera_vertical_degrees` (int): The camera's vertical view in degrees. This value is optional if the `lens_dimension` and `focal_length` are specified instead.
+
+If a custom set of config parameters is not provided add input, the add-on is initialized using the default parameteres shown above. 
+
+### Input
+
+The `post_process` gets as input the `AddonObject` and relies on the results of the `tracking` add-on set in:
+
+- `AddonObject.shared['trackable_objects']` (format: `OrderedDict`)
+- `AddonObject.shared['trackable_objects_history']` (format: `OrderedDict`)
+- `AddonObject.frame.shape` (format: `frame_height, frame_width`)
+
+**Direct dependency with the `tracking` add-on.**
+
+### Process
+
+After object detection and object tracking, the speed estimator receives the full history of `trackable_objects` from the `tracking` add-on. For every `trackable_object` we check its previous positions from the past frames and estimate the object's speed on the current frame.
+
+If an object is not tracked on the current frame, (due to low confidence detection or the person has temporarily disappeared from the fov), we assume its speed to be the same as the one from the previous frame. This assumes a stable speed throughout time for the next time we get a new detection and position for that object.
+
+When the flag `person_action`, we perform an additional processing step, where we calculate whether a person is 'walking | standing | running'. These actions are determined based on the assumption that the average running speed for a person is estimated around `9.1` kph and the average walking speed is `1.5` kph.
+
+
+### Output
+
+The add-on's output is shared on the `AddonObject.inference.extra` for each object that was actively tracked by the `tracking` add-on on the current frame:
+
+- `AddonObject.inference.extra['current_speed']` - (format: `dict` where `{'obj_id': speed}`)
+- `AddonObject.inference.extra['current_action']` - (format: `dict` where `{'obj_id': speed}`)
+

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup, find_namespace_packages
 
 setup(
     name='vsdkx-addon-speed-estimation',
-    url='https://github.com/natix-io/vsdkx-addon-tracking.git',
+    url='https://github.com/natix-io/vsdkx-addon-speed-estimation.git',
     author='Helmut',
-    author_email='helmut@natix.io',
+    author_email='nicole@natix.io',
     namespace_packages=['vsdkx', 'vsdkx.addon'],
     packages=find_namespace_packages(include=['vsdkx*']),
     dependency_links=[

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, find_namespace_packages
+
+setup(
+    name='vsdkx-addon-speed-estimation',
+    url='https://github.com/natix-io/vsdkx-addon-tracking.git',
+    author='Helmut',
+    author_email='helmut@natix.io',
+    namespace_packages=['vsdkx', 'vsdkx.addon'],
+    packages=find_namespace_packages(include=['vsdkx*']),
+    dependency_links=[
+        'git+https://gitlab+deploy-token-485942:VJtus51fGR59sMGhxHUF@gitlab.com/natix/cvison/vsdkx/vsdkx-core.git#egg=vsdkx-core'
+    ],
+    install_requires=[
+        'vsdkx-core',
+        'numpy>=1.18.5',
+    ],
+    version='1.0',
+)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_namespace_packages
 setup(
     name='vsdkx-addon-speed-estimation',
     url='https://github.com/natix-io/vsdkx-addon-speed-estimation.git',
-    author='Helmut',
+    author='Nicole',
     author_email='nicole@natix.io',
     namespace_packages=['vsdkx', 'vsdkx.addon'],
     packages=find_namespace_packages(include=['vsdkx*']),

--- a/vsdkx/__init__.py
+++ b/vsdkx/__init__.py
@@ -1,0 +1,1 @@
+__import__("pkg_resources").declare_namespace(__name__)

--- a/vsdkx/addon/__init__.py
+++ b/vsdkx/addon/__init__.py
@@ -1,0 +1,1 @@
+__import__("pkg_resources").declare_namespace(__name__)

--- a/vsdkx/addon/speed_estimation/processor.py
+++ b/vsdkx/addon/speed_estimation/processor.py
@@ -1,0 +1,191 @@
+import numpy as np
+
+from vsdkx.core.interfaces import Addon
+from vsdkx.core.structs import AddonObject
+
+
+class SpeedEstimationProcessor(Addon):
+    """
+    Calculate movement direction for objects based on their past and present
+    coordinates on the frame. This algorithm is based on the methodology
+    proposed on the following paper:
+
+    https://ieeexplore.ieee.org/document/6614066
+
+    Attributes:
+        person_action: (boolean) Flag on estimating actions such as
+            standing | walking | running
+        camera_length: (int|float) Distance from camera to furthest
+            object/ landmark in meters
+        fps: (int) Input frame rate
+        lens_dimension: (int) Camera lens dimension in millimeters. Optional
+            value if 'camera_horizontal_degrees' and
+            'camera_vertical_degrees' are specified instead.
+        focal_length: (int) Camera's focal length in millimeters. Optional
+            value if 'camera_horizontal_degrees' and
+            'camera_vertical_degrees' are specified instead.
+        camera_horizontal_degrees: (int) Camera's horizontal view in degrees.
+            Optional value if 'lens_dimension' and 'focal_length'
+            are specified instead.
+        camera_vertical_degrees: (int) Camera's vertical view in degrees.
+            Optional value if 'lens_dimension' and 'focal_length'
+            are specified instead.
+        _walking_action: (string) Constant string for walking action
+        _running_action: (string) Constant string for running action
+        _standing_action: (string) Constant string for standing action
+        _kph: (float) Constant for converting meters to kph
+        _average_running_kph: (float) Constant for average running speed in kph
+        _average_walking_kph: (float) Constant for average walking speed in kph
+    """
+
+    def __init__(self, addon_config: dict, model_settings: dict,
+                 model_config: dict, drawing_config: dict):
+        super().__init__(
+            addon_config, model_settings, model_config, drawing_config)
+        self.person_action = addon_config['person_action']
+        self.camera_length = addon_config['camera_length']  # meter
+        self.fps = addon_config['fps']
+        self.lens_dimension = addon_config['lens_dimension']  # mm
+        self.focal_length = addon_config['focal_length']
+        self.camera_horizontal_degrees = \
+            addon_config['camera_horizontal_degrees']
+        self.camera_vertical_degrees = \
+            addon_config['camera_vertical_degrees']
+
+        self._walking_action = 'walking'
+        self._standing_action = 'standing'
+        self._running_action = 'running'
+
+        self._kph = 3.6
+        self._average_running_kph = 9.1
+        self._average_walking_kph = 1.5
+
+    def post_process(self, addon_object: AddonObject) -> AddonObject:
+        """
+        Estimates the object's speed and action (for people) and write them
+        information in the extra dict under the 'current_speed' and
+        'current_action' keys.
+
+        Args:
+            addon_object(AddonObject): Addon object containing
+            'trackable_objects_history' key set in the shared attribute.
+        """
+
+        frame_height, frame_width, _ = addon_object.frame.shape
+        self._get_object_speed(
+            addon_object.shared.get("trackable_objects_history", {}),
+            frame_height,
+            frame_width
+        )
+        self._construct_result_dict(addon_object)
+
+        return addon_object
+
+    def _construct_result_dict(self, addon_object: AddonObject):
+        """
+        Constructs two dictionaries (conditional) to map the object id to its
+        estimated speed and action. The dictionaries are included in the
+        inference.extra dict of the addon_object.
+
+        Args:
+            addon_object(AddonObject): Addon object containing
+            'trackable_objects' key set in the shared attribute.
+        """
+        addon_object.inference.extra['current_speed'] = {
+            object_id: tracked_object.current_speed
+            for object_id, tracked_object
+            in addon_object.shared.get("trackable_objects", {}).items()
+        }
+
+        if self.person_action:
+            addon_object.inference.extra['current_action'] = {
+                object_id: tracked_object.action
+                for object_id, tracked_object
+                in addon_object.shared.get("trackable_objects", {}).items()
+            }
+
+    def _get_movement_action(self, speed: float):
+        """
+        Assigns the current action of the object based on its speed. The
+        actions in question are 'walking | standing | running|' and are
+        applicable to people detections.
+
+        Args:
+            speed: (float) Estimated speed of tracked object
+
+        Returns:
+            action: (string) walking | standing | running|
+        """
+
+        if speed >= self._average_running_kph:
+            action = self._running_action
+        elif speed >= self._average_walking_kph:
+            action = self._walking_action
+        else:
+            action = self._standing_action
+
+        return action
+
+    def _get_object_speed(self,
+                          tracked_objects: dict,
+                          frame_width: int,
+                          frame_height: int):
+        """
+        Estimates the moving speed of a detected and tracked object.
+
+        Args:
+            tracked_objects: (dict) Tracked objects by the object tracker in the
+                current frame
+            frame_width: (int) The width of the input frame
+            frame_height: (int) The height of the input frame
+        """
+
+        for _, tracked_object in tracked_objects.items():
+
+            if len(tracked_object.centroids) > 1:
+                past_centroid = tracked_object.centroids[-2]
+                current_centroid = tracked_object.centroids[-1]
+
+                if self.camera_horizontal_degrees == 0:
+                    a_x = 2 * np.arctan(self.lens_dimension /
+                                        (2 * self.focal_length))
+                else:
+                    a_x = self.camera_horizontal_degrees
+
+                if self.camera_vertical_degrees == 0:
+                    a_y = 2 * np.arctan(self.lens_dimension /
+                                        (2 * self.focal_length))
+                else:
+                    a_y = self.camera_vertical_degrees
+
+                x_real = 2 * self.camera_length * np.tan(np.degrees(a_x))
+                y_real = 2 * self.camera_length * np.tan(np.degrees(a_y))
+
+                v_x = (x_real / frame_width) * (
+                        (current_centroid[0] - past_centroid[0]) /
+                        (1 / self.fps))
+
+                v_y = (y_real / frame_height) * (
+                        (current_centroid[1] - past_centroid[1]) /
+                        (1 / self.fps))
+
+                v = np.sqrt((np.power(v_x, 2) + np.power(v_y, 2))) * self._kph
+                tracked_object.speeds.append(v)
+
+                if len(tracked_object.speeds) > self.fps:
+                    tracked_object.current_speed = sum(tracked_object.speeds[
+                                                       (len(
+                                                           tracked_object.speeds)
+                                                        - self.fps - 1):-1]) \
+                                                   / self.fps
+                else:
+                    tracked_object.current_speed = sum(
+                        tracked_object.speeds) / len(
+                        tracked_object.speeds)
+
+                if self.person_action:
+                    tracked_object.action = \
+                        self._get_movement_action(tracked_object.current_speed)
+            else:
+                tracked_object.speeds.append(0)
+                continue

--- a/vsdkx/addon/speed_estimation/settings.py
+++ b/vsdkx/addon/speed_estimation/settings.py
@@ -1,0 +1,9 @@
+DEFAULT = {
+    "person_action": True,
+    "camera_length": 4.5,
+    "fps": 30,
+    "lens_dimension": 0,
+    "focal_length": 0,
+    "camera_horizontal_degrees": 80,
+    "camera_vertical_degrees": 53
+}


### PR DESCRIPTION
## Description

Moves speed estimation add-on to its own repo and initializes it as an own plugin. 

### How to test

- Run visionx with a config set to trigger people detection, object tracking and the speed estimation with the following config:
```
addons:
  tracking:
    bidirectional_mode: False
    bidirectional_threshold: 150
    class: vsdkx.addon.tracking.processor.TrackerProcessor
    distance_threshold: 100
    max_disappeared: 10
    min_appearance: 1
  speed:
    class: vsdkx.addon.speed_estimation.processor.SpeedEstimationProcessor
    person_action: True
    camera_length: 3
    lens_dimension: 0 # optional if horizontal and vertical degrees are set
    focal_length: 0 # optional if horizontal and vertical degrees are set
    camera_horizontal_degrees: 114.5 # optional if lens dimension and focal length are set
    camera_vertical_degrees: 62 # optional if lens dimension and focal length are set
    fps: 15
```

- Run people detection with `make run` 

# What to expect 

In the current frame, if eg. 12 bounding boxes were detected, the results of speed estimation should equal to these 12 bounding boxes. For instance: 

```json
"addon_object.inference.extra"{
   "tracked_objects":0,
   "current_speed":{
      "0":0.6868643942827857,
      "1":0.0,
      "2":0.16209876027949038,
      "3":0.06329108462482329,
      "4":0.10552309389693124,
      "5":0.27291471769811937,
      "6":0.034956838481066926,
      "7":0.1898732538744699,
      "8":0.20799426146789335,
      "9":0.3788415479672548,
      "10":0.10552309389693124,
      "11":0.14598043117297102
   },
   "current_action":{
      "0":"standing",
      "1":"standing",
      "2":"standing",
      "3":"standing",
      "4":"standing",
      "5":"standing",
      "6":"standing",
      "7":"standing",
      "8":"standing",
      "9":"standing",
      "10":"standing",
      "11":"standing"
   }
}
```

Where the full `trackable_objects_history` contained 13 objects: 

```json
{
   "0":{
      "object_id":0
   },
   "1":{
      "object_id":1
   },
   "2":{
      "object_id":2
   },
   "3":{
      "object_id":3
   },
   "4":{
      "object_id":4
   },
   "5":{
      "object_id":5
   },
   "6":{
      "object_id":6
   },
   "7":{
      "object_id":7
   },
   "8":{
      "object_id":8
   },
   "9":{
      "object_id":9
   },
   "10":{
      "object_id":10
   },
   "11":{
      "object_id":11
   },
   "12":{
      "object_id":12
   }
}
``` 